### PR TITLE
BoxOffice [Step4] Volga

### DIFF
--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		C22297E12978570000D3FBC1 /* URLInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22297DF297856F500D3FBC1 /* URLInfo.swift */; };
 		C23B572A298C1C3F00138E2F /* AppKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23B5729298C1C3F00138E2F /* AppKeys.swift */; };
 		C23B572B298C1C3F00138E2F /* AppKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23B5729298C1C3F00138E2F /* AppKeys.swift */; };
+		C23B572D298C1CF800138E2F /* ImageSearchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23B572C298C1CF800138E2F /* ImageSearchResult.swift */; };
+		C23B572E298C1CF800138E2F /* ImageSearchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23B572C298C1CF800138E2F /* ImageSearchResult.swift */; };
 		C23FCF2F29764EAC002971B4 /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23FCF2E29764EAC002971B4 /* NetworkService.swift */; };
 		C23FCF3029764EB0002971B4 /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23FCF2E29764EAC002971B4 /* NetworkService.swift */; };
 		C23FCF3229765462002971B4 /* NetworkServiceError.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23FCF3129765462002971B4 /* NetworkServiceError.swift */; };
@@ -67,6 +69,7 @@
 		C22297DC297856D500D3FBC1 /* QueryKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryKeys.swift; sourceTree = "<group>"; };
 		C22297DF297856F500D3FBC1 /* URLInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLInfo.swift; sourceTree = "<group>"; };
 		C23B5729298C1C3F00138E2F /* AppKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKeys.swift; sourceTree = "<group>"; };
+		C23B572C298C1CF800138E2F /* ImageSearchResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageSearchResult.swift; sourceTree = "<group>"; };
 		C23FCF2E29764EAC002971B4 /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
 		C23FCF3129765462002971B4 /* NetworkServiceError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkServiceError.swift; sourceTree = "<group>"; };
 		C25A6AE829758BFA00C0E5C2 /* BoxOfficeSearchResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxOfficeSearchResult.swift; sourceTree = "<group>"; };
@@ -175,6 +178,7 @@
 			children = (
 				C25A6AE829758BFA00C0E5C2 /* BoxOfficeSearchResult.swift */,
 				C200490E2976F1BF00012C3F /* MovieListResult.swift */,
+				C23B572C298C1CF800138E2F /* ImageSearchResult.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -325,6 +329,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C23B572D298C1CF800138E2F /* ImageSearchResult.swift in Sources */,
 				C23FCF3229765462002971B4 /* NetworkServiceError.swift in Sources */,
 				C25A6AE929758BFA00C0E5C2 /* BoxOfficeSearchResult.swift in Sources */,
 				63DF20F32970E1A0005DF7D1 /* BoxOfficeListViewController.swift in Sources */,
@@ -356,6 +361,7 @@
 				C2004914297785C100012C3F /* NetworkServiceProtocol.swift in Sources */,
 				C22297E12978570000D3FBC1 /* URLInfo.swift in Sources */,
 				C270BDEB297BCD6F00362D16 /* MockURLSessionProtocol.swift in Sources */,
+				C23B572E298C1CF800138E2F /* ImageSearchResult.swift in Sources */,
 				C200490B2976BB8E00012C3F /* NetworkMockTests.swift in Sources */,
 				C270BDF2297BD01D00362D16 /* NetworkTest.swift in Sources */,
 				C23FCF3029764EB0002971B4 /* NetworkService.swift in Sources */,

--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		C23B572B298C1C3F00138E2F /* AppKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23B5729298C1C3F00138E2F /* AppKeys.swift */; };
 		C23B572D298C1CF800138E2F /* ImageSearchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23B572C298C1CF800138E2F /* ImageSearchResult.swift */; };
 		C23B572E298C1CF800138E2F /* ImageSearchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23B572C298C1CF800138E2F /* ImageSearchResult.swift */; };
+		C23B5730298C9F8E00138E2F /* DetailMovieInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23B572F298C9F8E00138E2F /* DetailMovieInfoViewController.swift */; };
+		C23B5731298C9F9000138E2F /* DetailMovieInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23B572F298C9F8E00138E2F /* DetailMovieInfoViewController.swift */; };
 		C23FCF2F29764EAC002971B4 /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23FCF2E29764EAC002971B4 /* NetworkService.swift */; };
 		C23FCF3029764EB0002971B4 /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23FCF2E29764EAC002971B4 /* NetworkService.swift */; };
 		C23FCF3229765462002971B4 /* NetworkServiceError.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23FCF3129765462002971B4 /* NetworkServiceError.swift */; };
@@ -70,6 +72,7 @@
 		C22297DF297856F500D3FBC1 /* URLInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLInfo.swift; sourceTree = "<group>"; };
 		C23B5729298C1C3F00138E2F /* AppKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKeys.swift; sourceTree = "<group>"; };
 		C23B572C298C1CF800138E2F /* ImageSearchResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageSearchResult.swift; sourceTree = "<group>"; };
+		C23B572F298C9F8E00138E2F /* DetailMovieInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailMovieInfoViewController.swift; sourceTree = "<group>"; };
 		C23FCF2E29764EAC002971B4 /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
 		C23FCF3129765462002971B4 /* NetworkServiceError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkServiceError.swift; sourceTree = "<group>"; };
 		C25A6AE829758BFA00C0E5C2 /* BoxOfficeSearchResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxOfficeSearchResult.swift; sourceTree = "<group>"; };
@@ -208,6 +211,7 @@
 			children = (
 				C2A9C8592988036B00895BE5 /* CellConfigurations */,
 				63DF20F22970E1A0005DF7D1 /* BoxOfficeListViewController.swift */,
+				C23B572F298C9F8E00138E2F /* DetailMovieInfoViewController.swift */,
 			);
 			path = Scene;
 			sourceTree = "<group>";
@@ -341,6 +345,7 @@
 				C23FCF2F29764EAC002971B4 /* NetworkService.swift in Sources */,
 				C23B572A298C1C3F00138E2F /* AppKeys.swift in Sources */,
 				C22297D92978553700D3FBC1 /* Ext+Date.swift in Sources */,
+				C23B5730298C9F8E00138E2F /* DetailMovieInfoViewController.swift in Sources */,
 				C200490F2976F1BF00012C3F /* MovieListResult.swift in Sources */,
 				C2A9C85E2988059E00895BE5 /* BoxOfficeItem.swift in Sources */,
 				C22297E0297856F500D3FBC1 /* URLInfo.swift in Sources */,
@@ -357,6 +362,7 @@
 				C23B572B298C1C3F00138E2F /* AppKeys.swift in Sources */,
 				C270BDEE297BCEC500362D16 /* jsonMockData.swift in Sources */,
 				C2A9C85F2988059E00895BE5 /* BoxOfficeItem.swift in Sources */,
+				C23B5731298C9F9000138E2F /* DetailMovieInfoViewController.swift in Sources */,
 				C22297DA2978554500D3FBC1 /* Ext+Date.swift in Sources */,
 				C2004914297785C100012C3F /* NetworkServiceProtocol.swift in Sources */,
 				C22297E12978570000D3FBC1 /* URLInfo.swift in Sources */,

--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		C22297DE297856D900D3FBC1 /* QueryKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22297DC297856D500D3FBC1 /* QueryKeys.swift */; };
 		C22297E0297856F500D3FBC1 /* URLInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22297DF297856F500D3FBC1 /* URLInfo.swift */; };
 		C22297E12978570000D3FBC1 /* URLInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22297DF297856F500D3FBC1 /* URLInfo.swift */; };
+		C23B572A298C1C3F00138E2F /* AppKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23B5729298C1C3F00138E2F /* AppKeys.swift */; };
+		C23B572B298C1C3F00138E2F /* AppKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23B5729298C1C3F00138E2F /* AppKeys.swift */; };
 		C23FCF2F29764EAC002971B4 /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23FCF2E29764EAC002971B4 /* NetworkService.swift */; };
 		C23FCF3029764EB0002971B4 /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23FCF2E29764EAC002971B4 /* NetworkService.swift */; };
 		C23FCF3229765462002971B4 /* NetworkServiceError.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23FCF3129765462002971B4 /* NetworkServiceError.swift */; };
@@ -64,6 +66,7 @@
 		C22297D82978553700D3FBC1 /* Ext+Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Ext+Date.swift"; sourceTree = "<group>"; };
 		C22297DC297856D500D3FBC1 /* QueryKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryKeys.swift; sourceTree = "<group>"; };
 		C22297DF297856F500D3FBC1 /* URLInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLInfo.swift; sourceTree = "<group>"; };
+		C23B5729298C1C3F00138E2F /* AppKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKeys.swift; sourceTree = "<group>"; };
 		C23FCF2E29764EAC002971B4 /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
 		C23FCF3129765462002971B4 /* NetworkServiceError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkServiceError.swift; sourceTree = "<group>"; };
 		C25A6AE829758BFA00C0E5C2 /* BoxOfficeSearchResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxOfficeSearchResult.swift; sourceTree = "<group>"; };
@@ -152,6 +155,7 @@
 			children = (
 				C22297DC297856D500D3FBC1 /* QueryKeys.swift */,
 				C22297DF297856F500D3FBC1 /* URLInfo.swift */,
+				C23B5729298C1C3F00138E2F /* AppKeys.swift */,
 			);
 			path = Constant;
 			sourceTree = "<group>";
@@ -330,6 +334,7 @@
 				63DF20F12970E1A0005DF7D1 /* SceneDelegate.swift in Sources */,
 				C2A9C85B2988038000895BE5 /* BoxOfficeListCell.swift in Sources */,
 				C23FCF2F29764EAC002971B4 /* NetworkService.swift in Sources */,
+				C23B572A298C1C3F00138E2F /* AppKeys.swift in Sources */,
 				C22297D92978553700D3FBC1 /* Ext+Date.swift in Sources */,
 				C200490F2976F1BF00012C3F /* MovieListResult.swift in Sources */,
 				C2A9C85E2988059E00895BE5 /* BoxOfficeItem.swift in Sources */,
@@ -344,6 +349,7 @@
 				C200490D2976BC4A00012C3F /* NetworkServiceError.swift in Sources */,
 				C25A6B042975924F00C0E5C2 /* BoxOfficeSearchResult.swift in Sources */,
 				C25A6AF629758CEA00C0E5C2 /* BoxOfficeResultTests.swift in Sources */,
+				C23B572B298C1C3F00138E2F /* AppKeys.swift in Sources */,
 				C270BDEE297BCEC500362D16 /* jsonMockData.swift in Sources */,
 				C2A9C85F2988059E00895BE5 /* BoxOfficeItem.swift in Sources */,
 				C22297DA2978554500D3FBC1 /* Ext+Date.swift in Sources */,

--- a/BoxOffice/Constant/AppKeys.swift
+++ b/BoxOffice/Constant/AppKeys.swift
@@ -1,0 +1,36 @@
+//
+//  AppKeys.swift
+//  BoxOffice
+//
+//  Created by kakao on 2023/02/03.
+//
+
+import Foundation
+
+enum AppKeys {
+    static let boxOfficeAPI: [String: String]? = {
+        guard let filePath = Bundle.main.url(forResource: "Info", withExtension: "plist") else {
+            return nil
+        }
+        guard let plist = NSDictionary(contentsOf: filePath) else {
+            return nil
+        }
+        guard let key = plist.object(forKey: "BOXOFFICE_APP_KEY") as? String else {
+            return nil
+        }
+        return ["key": key]
+    }()
+    
+    static let kakaoAPI: [String: String]? = {
+        guard let filePath = Bundle.main.url(forResource: "Info", withExtension: "plist") else {
+            return nil
+        }
+        guard let plist = NSDictionary(contentsOf: filePath) else {
+            return nil
+        }
+        guard let key = plist.object(forKey: "KAKAO_APP_KEY") as? String else {
+            return nil
+        }
+        return ["Authorization": "KakaoAK \(key)"]
+    }()
+}

--- a/BoxOffice/Constant/QueryKeys.swift
+++ b/BoxOffice/Constant/QueryKeys.swift
@@ -10,4 +10,9 @@ import Foundation
 enum QueryKeys {
     static let movieCode = "movieCd"
     static let targetDate = "targetDt"
+    static let imageKeyQuery = "query"
+    
+    static func imageQuery(_ movieName: String) -> String {
+        return "\(movieName) 영화 포스터"
+    }
 }

--- a/BoxOffice/Constant/URLInfo.swift
+++ b/BoxOffice/Constant/URLInfo.swift
@@ -8,22 +8,27 @@
 import Foundation
 
 enum URLInfo {
-    static let baseURL = "http://www.kobis.or.kr/"
-    static let key: URLQueryItem? = {
-        guard let filePath = Bundle.main.url(forResource: "Info", withExtension: "plist") else {
-            return nil
-        }
-        guard let plist = NSDictionary(contentsOf: filePath) else {
-            return nil
-        }
-        guard let key = plist.object(forKey: "APP_KEY") as? String else {
-            return nil
-        }
-        return URLQueryItem(name: "key", value: key)
-    }()
-    
     case searchDailyBoxOffice
     case searchDetailMovieInfo
+    case searchMoviePosterImage
+    
+    var scheme: String {
+        switch self {
+        case .searchDailyBoxOffice, .searchDetailMovieInfo:
+            return "http"
+        case .searchMoviePosterImage:
+            return "https"
+        }
+    }
+    
+    var host: String {
+        switch self {
+        case .searchDailyBoxOffice, .searchDetailMovieInfo:
+            return "kobis.or.kr"
+        case .searchMoviePosterImage:
+            return "dapi.kakao.com"
+        }
+    }
     
     var path: String {
         switch self {
@@ -31,6 +36,25 @@ enum URLInfo {
             return "/kobisopenapi/webservice/rest/boxoffice/searchDailyBoxOfficeList.json"
         case .searchDetailMovieInfo:
             return "/kobisopenapi/webservice/rest/movie/searchMovieInfo.json"
+        case .searchMoviePosterImage:
+            return "/v2/search/image"
+        }
+    }
+    
+    var defaultQuery: [URLQueryItem] {
+        switch self {
+        case .searchDailyBoxOffice, .searchDetailMovieInfo:
+            var queryItem: [URLQueryItem] = []
+            guard let keyQuery = AppKeys.boxOfficeAPI else {
+                return []
+            }
+            for query in keyQuery {
+                let appKey = URLQueryItem(name: query.key, value: query.value)
+                queryItem.append(appKey)
+            }
+            return queryItem
+        case .searchMoviePosterImage:
+            return []
         }
     }
 }

--- a/BoxOffice/Entity/BoxOfficeItem.swift
+++ b/BoxOffice/Entity/BoxOfficeItem.swift
@@ -12,6 +12,7 @@ struct BoxOfficeItem: Hashable {
     let showCountInformation: String
     let rank: String
     let rankDescription: NSAttributedString
+    let movieCode: String
     
     private enum BoxOfficeContents {
         static let newContents = "신작"
@@ -28,11 +29,13 @@ struct BoxOfficeItem: Hashable {
     init(title: String,
          showCountInformation: String,
          rank: String,
-         rankDescription: NSAttributedString) {
+         rankDescription: NSAttributedString,
+         movieCode: String) {
         self.title = title
         self.showCountInformation = showCountInformation
         self.rank = rank
         self.rankDescription = rankDescription
+        self.movieCode = movieCode
     }
     
     init(_ dailyItem: DailyBoxOffice) {
@@ -49,6 +52,7 @@ struct BoxOfficeItem: Hashable {
             .showCountInformation(todayShowCount, totalShowCount)
         self.rank = dailyItem.rank
         self.rankDescription = description
+        self.movieCode = dailyItem.movieCode
     }
 }
 

--- a/BoxOffice/Info.plist
+++ b/BoxOffice/Info.plist
@@ -7,8 +7,10 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
-	<key>APP_KEY</key>
+	<key>BOXOFFICE_APP_KEY</key>
 	<string>1a82fdb5f1e1ef5882cd8325ecb30e91</string>
+	<key>KAKAO_APP_KEY</key>
+	<string>ea216c079af4fa1b402818a6db6c04b8</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/BoxOffice/Models/ImageSearchResult.swift
+++ b/BoxOffice/Models/ImageSearchResult.swift
@@ -1,0 +1,39 @@
+//
+//  ImageSearchResult.swift
+//  BoxOffice
+//
+//  Created by kakao on 2023/02/03.
+//
+
+import Foundation
+
+struct ImageSearchResult: Decodable {
+    var imageInfos : [ImageInfo]
+    
+    enum CodingKeys: String, CodingKey {
+        case imageInfos = "documents"
+        
+    }
+}
+
+struct ImageInfo: Codable {
+    var collection      : String
+    var thumbnailUrl    : String
+    var imageUrl        : String
+    var width           : Int
+    var height          : Int
+    var displaySitename : String
+    var docUrl          : String
+    var datetime        : String
+    
+    enum CodingKeys: String, CodingKey {
+        case collection      = "collection"
+        case thumbnailUrl    = "thumbnail_url"
+        case imageUrl        = "image_url"
+        case width           = "width"
+        case height          = "height"
+        case displaySitename = "display_sitename"
+        case docUrl          = "doc_url"
+        case datetime        = "datetime"
+    }
+}

--- a/BoxOffice/Network/NetworkService.swift
+++ b/BoxOffice/Network/NetworkService.swift
@@ -30,7 +30,6 @@ final class NetworkService: NetworkServiceProtocol {
             completion(.failure(.invalidURLError))
             return
         }
-        print(url.description)
         let urlRequest = createHTTPRequest(of: url,
                                            with: headers,
                                            httpMethod: HTTPMethod.get)

--- a/BoxOffice/Network/Protocol/NetworkServiceProtocol.swift
+++ b/BoxOffice/Network/Protocol/NetworkServiceProtocol.swift
@@ -10,6 +10,7 @@ import Foundation
 protocol NetworkServiceProtocol {
     func fetch<T: Decodable> (
         searchTarget: URLInfo,
+        headers: [String: String]?,
         queryItems: [String: String]?,
         completion: @escaping (Result<T, NetworkServiceError>) -> Void
     )

--- a/BoxOffice/Scene/BoxOfficeListViewController.swift
+++ b/BoxOffice/Scene/BoxOfficeListViewController.swift
@@ -37,7 +37,7 @@ class BoxOfficeListViewController: UIViewController {
     private var dataSource: UICollectionViewDiffableDataSource<Section,
                                                                BoxOfficeItem>?
     private var items: [BoxOfficeItem] = []
-    private let networkService: NetworkServiceProtocol? = NetworkService()
+    private let networkService: NetworkServiceProtocol = NetworkService()
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -52,7 +52,7 @@ class BoxOfficeListViewController: UIViewController {
     }
     
     private func loadData(_ completion: @escaping () -> Void) {
-        networkService?.fetch(searchTarget: .searchDailyBoxOffice,
+        networkService.fetch(searchTarget: .searchDailyBoxOffice,
                               headers: nil,
                               queryItems: [QueryKeys.targetDate: Date
                                 .dayString(.yesterday,format: .yyyyMMdd)]) {
@@ -153,7 +153,8 @@ extension BoxOfficeListViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let row = indexPath.row
         let vc = DetailMovieInfoViewController(movieCode: items[row].movieCode,
-                                               movieName: items[row].title)
+                                               movieName: items[row].title,
+                                               networkService: networkService)
         navigationController?.pushViewController(vc, animated: true)
     }
 }

--- a/BoxOffice/Scene/BoxOfficeListViewController.swift
+++ b/BoxOffice/Scene/BoxOfficeListViewController.swift
@@ -30,6 +30,7 @@ class BoxOfficeListViewController: UIViewController {
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         collectionView.backgroundColor = .systemBackground
         collectionView.refreshControl = self.refreshBoxOfficeList
+        collectionView.delegate = self
         
         return collectionView
     }()
@@ -145,5 +146,14 @@ extension BoxOfficeListViewController {
         snapShot.appendSections([.main])
         snapShot.appendItems(items)
         dataSource?.apply(snapShot, animatingDifferences: false)
+    }
+}
+
+extension BoxOfficeListViewController: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        let row = indexPath.row
+        let vc = DetailMovieInfoViewController(movieCode: items[row].movieCode,
+                                               movieName: items[row].title)
+        navigationController?.pushViewController(vc, animated: true)
     }
 }

--- a/BoxOffice/Scene/BoxOfficeListViewController.swift
+++ b/BoxOffice/Scene/BoxOfficeListViewController.swift
@@ -52,6 +52,7 @@ class BoxOfficeListViewController: UIViewController {
     
     private func loadData(_ completion: @escaping () -> Void) {
         networkService?.fetch(searchTarget: .searchDailyBoxOffice,
+                              headers: nil,
                               queryItems: [QueryKeys.targetDate: Date
                                 .dayString(.yesterday,format: .yyyyMMdd)]) {
             [weak self] (response: Result<BoxOfficeSearchResult, NetworkServiceError>) -> Void in

--- a/BoxOffice/Scene/DetailMovieInfoViewController.swift
+++ b/BoxOffice/Scene/DetailMovieInfoViewController.swift
@@ -8,8 +8,53 @@
 import UIKit
 
 class DetailMovieInfoViewController: UIViewController {
+    private enum SubjectInfo {
+        static let director = "감독"
+        static let produceYear = "제작년도"
+        static let openDate = "개봉일"
+        static let showTime = "상영시간"
+        static let grade = "관람등급"
+        static let nation = "제작국가"
+        static let genre = "장르"
+        static let actors = "배우"
+    }
     private let movieCode: String
     private let movieName: String
+    
+    private let scrollView = UIScrollView()
+    private let mainStackView = UIStackView()
+    
+    private let directorNameStackView = UIStackView()
+    private let directorNameLabel = UILabel()
+    private let directorNameContentLabel = UILabel()
+    
+    private let produceYearStackView = UIStackView()
+    private let produceYearLabel = UILabel()
+    private let produceYearContentLabel = UILabel()
+    
+    private let openDateStackView = UIStackView()
+    private let openDateLabel = UILabel()
+    private let openDateContentLabel = UILabel()
+    
+    private let showTimeStackView = UIStackView()
+    private let showTimeLabel = UILabel()
+    private let showTimeContentLabel = UILabel()
+
+    private let gradeStackView = UIStackView()
+    private let gradeLabel = UILabel()
+    private let gradeContentLabel = UILabel()
+    
+    private let nationStackView = UIStackView()
+    private let nationLabel = UILabel()
+    private let nationContentLabel = UILabel()
+    
+    private let genreStackView = UIStackView()
+    private let genreLabel = UILabel()
+    private let genreContentLabel = UILabel()
+    
+    private let actorStackView = UIStackView()
+    private let actorLabel = UILabel()
+    private let actorContentLabel = UILabel()
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/BoxOffice/Scene/DetailMovieInfoViewController.swift
+++ b/BoxOffice/Scene/DetailMovieInfoViewController.swift
@@ -228,48 +228,48 @@ extension DetailMovieInfoViewController {
     }
     
     private func updateLabel(_ target: MovieInfo) {
-        DispatchQueue.main.async { [weak self] in
-            self?.directorNameContentLabel.text = target.directors.map { $0.name }.reduce(nil) {
-                (prev, next) in
-                guard let prev = prev else { return "\(next)" }
-                return "\(prev), \(next)"
-            }
-            self?.produceYearContentLabel.text = target.produceYear
-            self?.openDateContentLabel.text = target.openDate
-            self?.showTimeContentLabel.text = target.showTime
-            self?.gradeContentLabel.text = target.audits.map { $0.watchGradeName }.reduce(nil) {
-                (prev, next) in
-                guard let prev = prev else { return "\(next)" }
-                return "\(prev), \(next)"
-            }
-            self?.nationContentLabel.text = target.nations.map { $0.name }.reduce(nil) {
-                (prev, next) in
-                guard let prev = prev else { return "\(next)" }
-                return "\(prev), \(next)"
-            }
-            self?.genreContentLabel.text = target.genres.map { $0.name }.reduce(nil) {
-                (prev, next) in
-                guard let prev = prev else { return "\(next)" }
-                return "\(prev), \(next)"
-            }
-            self?.actorContentLabel.text = target.actors.map { $0.name }.reduce(nil) {
-                (prev, next) in
-                guard let prev = prev else { return "\(next)" }
-                return "\(prev), \(next)"
-            }
+        directorNameContentLabel.text = target.directors.map { $0.name }.reduce(nil) {
+            (prev, next) in
+            guard let prev = prev else { return "\(next)" }
+            return "\(prev), \(next)"
+        }
+        produceYearContentLabel.text = target.produceYear
+        openDateContentLabel.text = target.openDate
+        showTimeContentLabel.text = target.showTime
+        gradeContentLabel.text = target.audits.map { $0.watchGradeName }.reduce(nil) {
+            (prev, next) in
+            guard let prev = prev else { return "\(next)" }
+            return "\(prev), \(next)"
+        }
+        nationContentLabel.text = target.nations.map { $0.name }.reduce(nil) {
+            (prev, next) in
+            guard let prev = prev else { return "\(next)" }
+            return "\(prev), \(next)"
+        }
+        genreContentLabel.text = target.genres.map { $0.name }.reduce(nil) {
+            (prev, next) in
+            guard let prev = prev else { return "\(next)" }
+            return "\(prev), \(next)"
+        }
+        actorContentLabel.text = target.actors.map { $0.name }.reduce(nil) {
+            (prev, next) in
+            guard let prev = prev else { return "\(next)" }
+            return "\(prev), \(next)"
         }
     }
     
     private func loadDetailInfo() {
         networkService.fetch(searchTarget: .searchDetailMovieInfo,
-                              headers: nil,
-                              queryItems: [QueryKeys.movieCode: movieCode]) {
+                             headers: nil,
+                             queryItems: [QueryKeys.movieCode: movieCode]) {
             [weak self] (networkResponse: Result<MovieInfoDetailResult,
                          NetworkServiceError>) -> Void in
             switch networkResponse {
             case .success(let success):
                 let info = success.movieInfoResult.movieInfo
-                self?.updateLabel(info)
+                DispatchQueue.main.async {
+                    self?.updateLabel(info)
+                }
             case .failure(let error):
                 print(error.localizedDescription)
             }
@@ -283,24 +283,31 @@ extension DetailMovieInfoViewController {
         if let data = try? Data(contentsOf: url) {
             if let image = UIImage(data: data) {
                 DispatchQueue.main.async { [weak self] in
-                    self?.activityView.stopAnimating()
                     self?.posterImageView.image = image
                 }
             }
         }
     }
     
+    private func stopAnimateLoadingImage() {
+        DispatchQueue.main.async { [weak self] in
+            self?.activityView.stopAnimating()
+        }
+    }
+    
     private func loadMoviePoster() {
         networkService.fetch(searchTarget: .searchMoviePosterImage,
-                              headers: AppKeys.kakaoAPI,
-                              queryItems: [QueryKeys.imageKeyQuery: QueryKeys.imageQuery(movieName)]) {
+                             headers: AppKeys.kakaoAPI,
+                             queryItems: [QueryKeys.imageKeyQuery: QueryKeys.imageQuery(movieName)]) {
             [weak self] (networkResponse: Result<ImageSearchResult,
                          NetworkServiceError>) -> Void in
             switch networkResponse {
             case .success(let success):
                 self?.updateImage(success.imageInfos.first)
+                self?.stopAnimateLoadingImage()
             case .failure(let failure):
                 print(failure.localizedDescription)
+                self?.stopAnimateLoadingImage()
             }
         }
     }

--- a/BoxOffice/Scene/DetailMovieInfoViewController.swift
+++ b/BoxOffice/Scene/DetailMovieInfoViewController.swift
@@ -13,7 +13,6 @@ class DetailMovieInfoViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        print(movieCode, movieName)
         configureAttribute()
         configureHierarchy()
         configureLayout()

--- a/BoxOffice/Scene/DetailMovieInfoViewController.swift
+++ b/BoxOffice/Scene/DetailMovieInfoViewController.swift
@@ -21,7 +21,7 @@ class DetailMovieInfoViewController: UIViewController {
     private let movieCode: String
     private let movieName: String
     
-    private let networkService: NetworkServiceProtocol? = NetworkService()
+    private let networkService: NetworkServiceProtocol
     
     private let scrollView = UIScrollView()
     private let mainStackView = UIStackView()
@@ -70,9 +70,12 @@ class DetailMovieInfoViewController: UIViewController {
         loadMoviePoster()
     }
     
-    init(movieCode: String, movieName: String) {
+    init(movieCode: String,
+         movieName: String,
+         networkService: NetworkServiceProtocol) {
         self.movieCode = movieCode
         self.movieName = movieName
+        self.networkService = networkService
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -258,7 +261,7 @@ extension DetailMovieInfoViewController {
     }
     
     private func loadDetailInfo() {
-        networkService?.fetch(searchTarget: .searchDetailMovieInfo,
+        networkService.fetch(searchTarget: .searchDetailMovieInfo,
                               headers: nil,
                               queryItems: [QueryKeys.movieCode: movieCode]) {
             [weak self] (networkResponse: Result<MovieInfoDetailResult,
@@ -288,7 +291,7 @@ extension DetailMovieInfoViewController {
     }
     
     private func loadMoviePoster() {
-        networkService?.fetch(searchTarget: .searchMoviePosterImage,
+        networkService.fetch(searchTarget: .searchMoviePosterImage,
                               headers: AppKeys.kakaoAPI,
                               queryItems: [QueryKeys.imageKeyQuery: QueryKeys.imageQuery(movieName)]) {
             [weak self] (networkResponse: Result<ImageSearchResult,

--- a/BoxOffice/Scene/DetailMovieInfoViewController.swift
+++ b/BoxOffice/Scene/DetailMovieInfoViewController.swift
@@ -1,0 +1,15 @@
+//
+//  DetailMovieInfoViewController.swift
+//  BoxOffice
+//
+//  Created by kakao on 2023/02/03.
+//
+
+import UIKit
+
+class DetailMovieInfoViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}

--- a/BoxOffice/Scene/DetailMovieInfoViewController.swift
+++ b/BoxOffice/Scene/DetailMovieInfoViewController.swift
@@ -8,8 +8,38 @@
 import UIKit
 
 class DetailMovieInfoViewController: UIViewController {
+    private let movieCode: String
+    private let movieName: String
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        print(movieCode, movieName)
+        configureAttribute()
+        configureHierarchy()
+        configureLayout()
+    }
+    
+    init(movieCode: String, movieName: String) {
+        self.movieCode = movieCode
+        self.movieName = movieName
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+}
+
+extension DetailMovieInfoViewController {
+    private func configureAttribute() {
+        view.backgroundColor = .systemBackground
+    }
+    
+    private func configureHierarchy() {
+        
+    }
+    
+    private func configureLayout() {
+        
     }
 }

--- a/BoxOffice/Scene/DetailMovieInfoViewController.swift
+++ b/BoxOffice/Scene/DetailMovieInfoViewController.swift
@@ -77,13 +77,137 @@ class DetailMovieInfoViewController: UIViewController {
 extension DetailMovieInfoViewController {
     private func configureAttribute() {
         view.backgroundColor = .systemBackground
+        
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        
+        mainStackView.layoutMargins = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
+        mainStackView.isLayoutMarginsRelativeArrangement = true
+        mainStackView.translatesAutoresizingMaskIntoConstraints = false
+        mainStackView.axis = .vertical
+        mainStackView.spacing = 10
+        
+        [
+            directorNameStackView, produceYearStackView, openDateStackView,
+            showTimeStackView, gradeStackView, nationStackView,
+            genreStackView, actorStackView
+        ].forEach { stackView in
+            stackView.axis = .horizontal
+            stackView.translatesAutoresizingMaskIntoConstraints = false
+        }
+        
+        [
+            directorNameLabel, produceYearLabel, openDateLabel,
+            showTimeLabel, gradeLabel, nationLabel,
+            genreLabel, actorLabel
+        ].forEach { label in
+            label.adjustsFontForContentSizeCategory = true
+            label.font = .systemFont(ofSize: label.font.pointSize, weight: .bold)
+            label.textAlignment = .center
+            label.numberOfLines = 0
+            label.translatesAutoresizingMaskIntoConstraints = false
+        }
+        
+        directorNameLabel.text = SubjectInfo.director
+        produceYearLabel.text = SubjectInfo.produceYear
+        openDateLabel.text = SubjectInfo.openDate
+        showTimeLabel.text = SubjectInfo.showTime
+        gradeLabel.text = SubjectInfo.grade
+        nationLabel.text = SubjectInfo.nation
+        genreLabel.text = SubjectInfo.genre
+        actorLabel.text = SubjectInfo.actors
+        
+        [
+            directorNameContentLabel, produceYearContentLabel, openDateContentLabel,
+            showTimeContentLabel, gradeContentLabel, nationContentLabel,
+            genreContentLabel, actorContentLabel
+        ].forEach { label in
+            label.adjustsFontForContentSizeCategory = true
+            label.numberOfLines = 0
+            label.translatesAutoresizingMaskIntoConstraints = false
+        }
     }
     
     private func configureHierarchy() {
+        [directorNameLabel, directorNameContentLabel].forEach { label in
+            directorNameStackView.addArrangedSubview(label)
+        }
         
+        [produceYearLabel, produceYearContentLabel].forEach { label in
+            produceYearStackView.addArrangedSubview(label)
+        }
+        
+        [openDateLabel, openDateContentLabel].forEach { label in
+            openDateStackView.addArrangedSubview(label)
+        }
+        
+        [showTimeLabel, showTimeContentLabel].forEach { label in
+            showTimeStackView.addArrangedSubview(label)
+        }
+        
+        [gradeLabel, gradeContentLabel].forEach { label in
+            gradeStackView.addArrangedSubview(label)
+        }
+        
+        [nationLabel, nationContentLabel].forEach { label in
+            nationStackView.addArrangedSubview(label)
+        }
+        
+        [genreLabel, genreContentLabel].forEach { label in
+            genreStackView.addArrangedSubview(label)
+        }
+        
+        [actorLabel, actorContentLabel].forEach { label in
+            actorStackView.addArrangedSubview(label)
+        }
+        
+        [
+            directorNameStackView, produceYearStackView, openDateStackView,
+            showTimeStackView, gradeStackView, nationStackView,
+            genreStackView, actorStackView
+        ].forEach { stackView in
+            mainStackView.addArrangedSubview(stackView)
+        }
+        
+        scrollView.addSubview(mainStackView)
+        view.addSubview(scrollView)
     }
     
     private func configureLayout() {
-        
+        NSLayoutConstraint.activate([
+            directorNameLabel
+                .widthAnchor.constraint(equalTo: directorNameStackView.widthAnchor, multiplier: 0.2),
+            produceYearLabel
+                .widthAnchor.constraint(equalTo: produceYearStackView.widthAnchor, multiplier: 0.2),
+            openDateLabel
+                .widthAnchor.constraint(equalTo: openDateStackView.widthAnchor, multiplier: 0.2),
+            showTimeLabel
+                .widthAnchor.constraint(equalTo: showTimeStackView.widthAnchor, multiplier: 0.2),
+            gradeLabel
+                .widthAnchor.constraint(equalTo: gradeStackView.widthAnchor, multiplier: 0.2),
+            nationLabel
+                .widthAnchor.constraint(equalTo: nationStackView.widthAnchor, multiplier: 0.2),
+            genreLabel
+                .widthAnchor.constraint(equalTo: genreStackView.widthAnchor, multiplier: 0.2),
+            actorLabel
+                .widthAnchor.constraint(equalTo: actorStackView.widthAnchor, multiplier: 0.2),
+            mainStackView
+                .leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            mainStackView
+                .trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+            mainStackView
+                .bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            mainStackView
+                .topAnchor.constraint(equalTo: scrollView.topAnchor),
+            mainStackView
+                .widthAnchor.constraint(equalTo: scrollView.widthAnchor),
+            scrollView
+                .leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView
+                .trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView
+                .bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            scrollView
+                .topAnchor.constraint(equalTo: view.topAnchor)
+        ])
     }
 }

--- a/BoxOfficeTests/NetworkTest/NetworkMockTests.swift
+++ b/BoxOfficeTests/NetworkTest/NetworkMockTests.swift
@@ -30,6 +30,7 @@ final class NetworkMockTests: XCTestCase {
 
         let expects = XCTestExpectation(description: "영화 정보 TEST Expecatation")
         urlSession.fetch(searchTarget: .searchDetailMovieInfo,
+                         headers: nil,
                          queryItems: [QueryKeys.movieCode: "20124079"]) {
             (networkResult: Result<MovieInfoDetailResult, NetworkServiceError>) -> Void in
             switch networkResult {
@@ -55,6 +56,7 @@ final class NetworkMockTests: XCTestCase {
         
         let expects = XCTestExpectation(description: "오늘의 박스 오피스 TEST Expecatation")
         urlSession.fetch(searchTarget: .searchDailyBoxOffice,
+                         headers: nil,
                          queryItems: [QueryKeys.targetDate: Date.dayString(.today, format: .yyyyMMdd)]) {
             (networkResult: Result<BoxOfficeSearchResult, NetworkServiceError>) -> Void in
             switch networkResult {
@@ -80,6 +82,7 @@ final class NetworkMockTests: XCTestCase {
         
         let expects = XCTestExpectation(description: "오늘의 박스 오피스 TEST Expecatation")
         urlSession.fetch(searchTarget: .searchDailyBoxOffice,
+                         headers: nil,
                          queryItems: [QueryKeys.targetDate: Date.dayString(.today, format: .yyyyMMdd)]) {
             (networkResult: Result<BoxOfficeSearchResult, NetworkServiceError>) -> Void in
             switch networkResult {
@@ -105,6 +108,7 @@ final class NetworkMockTests: XCTestCase {
         
         let expects = XCTestExpectation(description: "오늘의 박스 오피스 TEST Expecatation")
         urlSession.fetch(searchTarget: .searchDailyBoxOffice,
+                         headers: nil,
                          queryItems: [QueryKeys.targetDate: Date.dayString(.today, format: .yyyyMMdd)]) {
             (networkResult: Result<BoxOfficeSearchResult, NetworkServiceError>) -> Void in
             switch networkResult {

--- a/BoxOfficeTests/NetworkTest/NetworkTest.swift
+++ b/BoxOfficeTests/NetworkTest/NetworkTest.swift
@@ -103,7 +103,7 @@ final class NetworkTest: XCTestCase {
                 print(success)
                 expects.fulfill()
             case .failure(let failure):
-                XCTFail()
+                XCTFail(failure.localizedDescription)
                 expects.fulfill()
             }
         }

--- a/BoxOfficeTests/NetworkTest/NetworkTest.swift
+++ b/BoxOfficeTests/NetworkTest/NetworkTest.swift
@@ -18,7 +18,8 @@ final class NetworkTest: XCTestCase {
         let expects = XCTestExpectation(description: "영화 정보 TEST Expecatation")
         
         sut.fetch(searchTarget: .searchDetailMovieInfo,
-                         queryItems: [QueryKeys.movieCode: "20124079"]) {
+                  headers: nil,
+                  queryItems: [QueryKeys.movieCode: "20124079"]) {
             (networkResult: Result<MovieInfoDetailResult, NetworkServiceError>) -> Void in
             switch networkResult {
             case .success(let success):
@@ -36,7 +37,8 @@ final class NetworkTest: XCTestCase {
         let expects = XCTestExpectation(description: "오늘의 박스 오피스 TEST Expecatation")
         
         sut.fetch(searchTarget: .searchDailyBoxOffice,
-                         queryItems: [QueryKeys.targetDate: Date.dayString(.today, format: .yyyyMMdd)]) {
+                  headers: nil,
+                  queryItems: [QueryKeys.targetDate: Date.dayString(.today, format: .yyyyMMdd)]) {
             (networkResult: Result<BoxOfficeSearchResult, NetworkServiceError>) -> Void in
             switch networkResult {
             case .success(let success):
@@ -54,11 +56,12 @@ final class NetworkTest: XCTestCase {
         let expects = XCTestExpectation(description: "오늘의 박스 오피스 TEST Expecatation")
         
         sut.fetch(searchTarget: .searchDailyBoxOffice,
-                  queryItems: [QueryKeys.targetDate: Date.dayString(.today, format: .yyyyMMdd)]) {
+                  headers: nil,
+                  queryItems: [QueryKeys.targetDate: Date.dayString(.yesterday, format: .yyyyMMdd)]) {
             (networkResult: Result<BoxOfficeSearchResult, NetworkServiceError>) -> Void in
             switch networkResult {
             case .success(let success):
-                let today = Date.dayString(.today, format: .yyyyMMdd)
+                let today = Date.dayString(.yesterday, format: .yyyyMMdd)
                 XCTAssertEqual(success.result.searchRange, "\(today)~\(today)")
                 expects.fulfill()
             case .failure(let failure):
@@ -73,7 +76,8 @@ final class NetworkTest: XCTestCase {
         let expects = XCTestExpectation(description: "오늘의 박스 오피스 TEST Expecatation")
         
         sut.fetch(searchTarget: .searchDailyBoxOffice,
-                         queryItems: [QueryKeys.targetDate: Date.dayString(.today, format: .yyyyMMdd)]) {
+                  headers: nil,
+                  queryItems: [QueryKeys.targetDate: Date.dayString(.today, format: .yyyyMMdd)]) {
             (networkResult: Result<BoxOfficeSearchResult, NetworkServiceError>) -> Void in
             switch networkResult {
             case .success(let success):
@@ -86,6 +90,23 @@ final class NetworkTest: XCTestCase {
         }
         wait(for: [expects], timeout: 5.0)
     }
-
-
+    
+    func test_images_잘_받아_오나() {
+        let expects = XCTestExpectation(description: "오늘의 이미지 렌더링")
+        
+        sut.fetch(searchTarget: .searchMoviePosterImage,
+                  headers: AppKeys.kakaoAPI,
+                  queryItems: ["query": "슬램덩크 영화 포스터"]) {
+            (networkResult: Result<ImageSearchResult, NetworkServiceError>) -> Void in
+            switch networkResult {
+            case .success(let success):
+                print(success)
+                expects.fulfill()
+            case .failure(let failure):
+                XCTFail()
+                expects.fulfill()
+            }
+        }
+        wait(for: [expects], timeout: 5.0)
+    }
 }


### PR DESCRIPTION
@zdodev 

안녕하세요~ 소대!

STEP4 PR을 보내드립니다..!

# 요구사항

- 영화의 상세내용을 확인할 수 있는 화면을 구현합니다.
- 표시할 영화 정보
    - 제목 [✅ ]
    - 포스터 이미지[✅ ]
    - 감독[✅ ]
    - 제작년도[✅ ]
    - 개봉일[✅ ]
    - 상영시간[✅ ]
    - 관람등급[✅ ]
    - 제작국가[✅ ]
    - 장르[✅ ]
    - 배우[✅ ]
- 이미지가 로드되기 전에는 이미지가 로드중임을 알 수 있도록 적절히 처리해주세요 [✅ ]
- 내용이 길어지면 위아래로 스크롤 할 수 있도록 구현해주세요.[✅ ]

## 고민한 점
- 기존에 쓰던 `URLInfo` 을 많이 수정했습니다.
    - 타입 프로퍼티로 `baseURL`을 가져다 사용했었는데 카카오 API에 대한 접근이 필요해진만큼 `baseURL` 대신 `URLComponents`에 `scheme`, `path`, `host`, `query`를 넣어서 만드는 방식으로 구현사항을 변경했습니다.
    - 기존에 `App Key`를 `URLInfo`에서 얻어올수 있게 만들었는데, `Key`에 대한 구현 방식에 대해서, `AppKeys`의 타입 프로퍼티로 가져올수 있게 구현사항을 변경했습니다.
        - 박스오피스 & 카카오 앱 키 모두 `Header` 또는 `Query`에 넣든 `Dictionary` 형태의 상태가 필요하므로 공통적으로 `[String: String]` 형태로 반환하게 구현했습니다.
- `NetworkService`  내부 `fetch()`메소드에 파리미터로 `Header: [String: String]?`을 추가했습니다.
    - 박스 오피스 앱 키가 기존에 쿼리로만 들어갔던 것을 고려하여 뺏던 헤더 부분을 추가했고 URLRequest를 만드는 과정에서 추가하게 변경했습니다.
    - HTTPHeader 정보로 필요한 `Method`에 대해 Enum으로 구현했습니다.
- `DetailMovieInfoViewController` 구현 사항중,`영화 정보`와 `포스터 이미지`에 대해 따로 받아오는 메소드를 구현했습니다.
- `DetailMovieInfoViewController` 에서 `movieCode`, `movieName`프로퍼티를 선언해서 `BoxOfficeListViewController`에서 주입하여 사용하게 구현했습니다.
- 다음화면으로 `movieCode`와 `movieName`이 필요한 만큼 해당 부분에 대해 넘겨 줄 수 있도록 `BoxOfficeItem`에 `movieCode`를 추가했습니다.

## 궁금한 점
- `DetailMovieInfoViewController`로 프로퍼티 정보를 주입해서 넘겨주기 위해서 BoxOfficeItem에 새로운 프로퍼티를 추가해서 구현을 했는데, 이게 객체지향적으로 올바른거 같지 않다고 생각은 하지만, 다른 방식으로 값을 넘겨 주는 것에 대해 방도를 잘 모르겠습니다. (애초에 저장하지 않는 정보를 어떻게.. 넘기지? 라는 생각입니다.)
- `ActivityIndicator`를 `mainStackView` 최 상단에 넣어놓고 `Animating`을 시켜놨는데, 이 부분에 대해서 더 좋은 방법이 있는지 궁금합니다. 