### PR TITLE
박스오피스 [Step 5] Volga

### DIFF
--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -25,6 +25,10 @@
 		C22297DE297856D900D3FBC1 /* QueryKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22297DC297856D500D3FBC1 /* QueryKeys.swift */; };
 		C22297E0297856F500D3FBC1 /* URLInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22297DF297856F500D3FBC1 /* URLInfo.swift */; };
 		C22297E12978570000D3FBC1 /* URLInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22297DF297856F500D3FBC1 /* URLInfo.swift */; };
+		C22DC4762993F59B0013E3A8 /* ImageCacheUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22DC4752993F59B0013E3A8 /* ImageCacheUtility.swift */; };
+		C22DC4772993F59B0013E3A8 /* ImageCacheUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22DC4752993F59B0013E3A8 /* ImageCacheUtility.swift */; };
+		C22DC47A2993FA840013E3A8 /* CacheError.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22DC4792993FA840013E3A8 /* CacheError.swift */; };
+		C22DC47B2993FA840013E3A8 /* CacheError.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22DC4792993FA840013E3A8 /* CacheError.swift */; };
 		C23B572A298C1C3F00138E2F /* AppKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23B5729298C1C3F00138E2F /* AppKeys.swift */; };
 		C23B572B298C1C3F00138E2F /* AppKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23B5729298C1C3F00138E2F /* AppKeys.swift */; };
 		C23B572D298C1CF800138E2F /* ImageSearchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23B572C298C1CF800138E2F /* ImageSearchResult.swift */; };
@@ -70,6 +74,8 @@
 		C22297D82978553700D3FBC1 /* Ext+Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Ext+Date.swift"; sourceTree = "<group>"; };
 		C22297DC297856D500D3FBC1 /* QueryKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryKeys.swift; sourceTree = "<group>"; };
 		C22297DF297856F500D3FBC1 /* URLInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLInfo.swift; sourceTree = "<group>"; };
+		C22DC4752993F59B0013E3A8 /* ImageCacheUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheUtility.swift; sourceTree = "<group>"; };
+		C22DC4792993FA840013E3A8 /* CacheError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheError.swift; sourceTree = "<group>"; };
 		C23B5729298C1C3F00138E2F /* AppKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKeys.swift; sourceTree = "<group>"; };
 		C23B572C298C1CF800138E2F /* ImageSearchResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageSearchResult.swift; sourceTree = "<group>"; };
 		C23B572F298C9F8E00138E2F /* DetailMovieInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailMovieInfoViewController.swift; sourceTree = "<group>"; };
@@ -124,6 +130,7 @@
 		63DF20ED2970E1A0005DF7D1 /* BoxOffice */ = {
 			isa = PBXGroup;
 			children = (
+				C22DC4742993F55A0013E3A8 /* Utility */,
 				C22297DB297856CC00D3FBC1 /* Constant */,
 				C22297D7297854BF00D3FBC1 /* Ext+ */,
 				C23FCF2D29764E8E002971B4 /* Network */,
@@ -159,11 +166,28 @@
 		C22297DB297856CC00D3FBC1 /* Constant */ = {
 			isa = PBXGroup;
 			children = (
+				C22DC4782993FA740013E3A8 /* Errors */,
 				C22297DC297856D500D3FBC1 /* QueryKeys.swift */,
 				C22297DF297856F500D3FBC1 /* URLInfo.swift */,
 				C23B5729298C1C3F00138E2F /* AppKeys.swift */,
 			);
 			path = Constant;
+			sourceTree = "<group>";
+		};
+		C22DC4742993F55A0013E3A8 /* Utility */ = {
+			isa = PBXGroup;
+			children = (
+				C22DC4752993F59B0013E3A8 /* ImageCacheUtility.swift */,
+			);
+			path = Utility;
+			sourceTree = "<group>";
+		};
+		C22DC4782993FA740013E3A8 /* Errors */ = {
+			isa = PBXGroup;
+			children = (
+				C22DC4792993FA840013E3A8 /* CacheError.swift */,
+			);
+			path = Errors;
 			sourceTree = "<group>";
 		};
 		C23FCF2D29764E8E002971B4 /* Network */ = {
@@ -334,6 +358,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C23B572D298C1CF800138E2F /* ImageSearchResult.swift in Sources */,
+				C22DC47A2993FA840013E3A8 /* CacheError.swift in Sources */,
 				C23FCF3229765462002971B4 /* NetworkServiceError.swift in Sources */,
 				C25A6AE929758BFA00C0E5C2 /* BoxOfficeSearchResult.swift in Sources */,
 				63DF20F32970E1A0005DF7D1 /* BoxOfficeListViewController.swift in Sources */,
@@ -346,6 +371,7 @@
 				C23B572A298C1C3F00138E2F /* AppKeys.swift in Sources */,
 				C22297D92978553700D3FBC1 /* Ext+Date.swift in Sources */,
 				C23B5730298C9F8E00138E2F /* DetailMovieInfoViewController.swift in Sources */,
+				C22DC4762993F59B0013E3A8 /* ImageCacheUtility.swift in Sources */,
 				C200490F2976F1BF00012C3F /* MovieListResult.swift in Sources */,
 				C2A9C85E2988059E00895BE5 /* BoxOfficeItem.swift in Sources */,
 				C22297E0297856F500D3FBC1 /* URLInfo.swift in Sources */,
@@ -358,8 +384,10 @@
 			files = (
 				C200490D2976BC4A00012C3F /* NetworkServiceError.swift in Sources */,
 				C25A6B042975924F00C0E5C2 /* BoxOfficeSearchResult.swift in Sources */,
+				C22DC47B2993FA840013E3A8 /* CacheError.swift in Sources */,
 				C25A6AF629758CEA00C0E5C2 /* BoxOfficeResultTests.swift in Sources */,
 				C23B572B298C1C3F00138E2F /* AppKeys.swift in Sources */,
+				C22DC4772993F59B0013E3A8 /* ImageCacheUtility.swift in Sources */,
 				C270BDEE297BCEC500362D16 /* jsonMockData.swift in Sources */,
 				C2A9C85F2988059E00895BE5 /* BoxOfficeItem.swift in Sources */,
 				C23B5731298C9F9000138E2F /* DetailMovieInfoViewController.swift in Sources */,

--- a/BoxOffice/Constant/Errors/CacheError.swift
+++ b/BoxOffice/Constant/Errors/CacheError.swift
@@ -1,0 +1,13 @@
+//
+//  CacheError.swift
+//  BoxOffice
+//
+//  Created by kakao on 2023/02/09.
+//
+
+import Foundation
+
+enum CacheError: Error {
+    case absentCashedImage
+    case inValidCashedImageData
+}

--- a/BoxOffice/Scene/DetailMovieInfoViewController.swift
+++ b/BoxOffice/Scene/DetailMovieInfoViewController.swift
@@ -92,7 +92,6 @@ extension DetailMovieInfoViewController {
         posterImageView.contentMode = .scaleAspectFit
         
         activityView.translatesAutoresizingMaskIntoConstraints = false
-        activityView.startAnimating()
         
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         
@@ -296,6 +295,7 @@ extension DetailMovieInfoViewController {
     }
     
     private func loadMoviePoster() {
+        activityView.startAnimating()
         networkService.fetch(searchTarget: .searchMoviePosterImage,
                              headers: AppKeys.kakaoAPI,
                              queryItems: [QueryKeys.imageKeyQuery: QueryKeys.imageQuery(movieName)]) {

--- a/BoxOffice/Scene/DetailMovieInfoViewController.swift
+++ b/BoxOffice/Scene/DetailMovieInfoViewController.swift
@@ -279,11 +279,9 @@ extension DetailMovieInfoViewController {
         guard let imageInfo = imageInfo, let url = URL(string: imageInfo.imageUrl) else {
             return
         }
-        if let data = try? Data(contentsOf: url) {
-            if let image = UIImage(data: data) {
-                DispatchQueue.main.async { [weak self] in
-                    self?.posterImageView.image = image
-                }
+        ImageCacheUtility.fetchImage(imageURL: url) { data in
+            DispatchQueue.main.async { [weak self] in
+                self?.posterImageView.image = UIImage(data: data)
             }
         }
     }

--- a/BoxOffice/Utility/ImageCacheUtility.swift
+++ b/BoxOffice/Utility/ImageCacheUtility.swift
@@ -1,0 +1,68 @@
+//
+//  ImageDownLoadUtility.swift
+//  BoxOffice
+//
+//  Created by kakao on 2023/02/09.
+//
+
+import Foundation
+
+final class ImageCacheUtility {
+    private init() {}
+    static let imageCache = URLCache(memoryCapacity: 30 * 1024 * 1024,
+                                     diskCapacity: 10 * 1024 * 1024,
+                                     directory: cacheDirectory)
+    private static let cacheDirectory: URL? = {
+        let url = try? FileManager.default.url(for: .cachesDirectory,
+                                               in: .allDomainsMask,
+                                               appropriateFor: nil,
+                                               create: false)
+        return url
+    }()
+    
+    static func fetchImage(imageURL: URL, completion: @escaping (Data) -> Void) {
+        let request = URLRequest(url: imageURL)
+        
+        self.loadImageFromCache(request: request) { result in
+            switch result {
+            case .success(let imageData):
+                completion(imageData)
+            case .failure:
+                self.downloadImage(request: request) { imageData in
+                    completion(imageData)
+                }
+            }
+        }
+    }
+    
+    private static func downloadImage(
+        request: URLRequest,
+        completion: @escaping (Data) -> Void
+    ) {
+        let task = URLSession.shared.dataTask(with: request) { data, response, _ in
+            guard let data = data else {
+                return
+            }
+            guard let response = response as? HTTPURLResponse,
+                  (200...299).contains(response.statusCode) else {
+                return
+            }
+            let cachedResponse = CachedURLResponse(response: response, data: data)
+            imageCache.storeCachedResponse(cachedResponse, for: request)
+            
+            completion(data)
+        }
+        task.resume()
+    }
+    
+    private static func loadImageFromCache(
+        request: URLRequest,
+        completion: @escaping (Result<Data, CacheError>) -> Void
+    ) {
+        if let imageData = imageCache.cachedResponse(for: request)?.data {
+            completion(.success(imageData))
+        } else {
+            completion(.failure(.absentCashedImage))
+        }
+    }
+}


### PR DESCRIPTION
@zdodev 
안녕하세요.. 소대!

STEP5 PR을 올립니다.

## 명세사항

- 네트워크 통신을 통해 받아온 데이터를 로컬에 캐시합니다
- CoreData, URLCache 등의 방식을 활용할 수 있습니다
- 캐시한 데이터는 iOS File System에서 어디에 위치하면 좋을까요?
- 캐싱할 데이터의 범위와 활용 범위, 잔존 기한 등 캐시 정책을 미리 세우고 구현을 시작합시다

## 고민한 점

- 캐싱 데이터 활용 범위
    - 캐싱 데이터는 영화 포스터 `Image`를 받아오는 것으로 활용 범위를 제한했습니다.
    - 박스오피스 리스트 + 영화 정보 에 대한 JSON은 데이터가 변경 될 가능성이 존재하므로, 캐싱하는 것에 대해 유의미한 결과를 획득하기 어렵다고 판단했습니다.
- Cache를 위해 NSCache / URLCache 둘 중 하나를 선택해야 했는데, 어떠한 기준으로 선택해야 했는가?
    - `Cache`하는 대상이 `Image`인 만큼 In-Memory 방식보다는 디스크도 사용하면 좋겠다 싶었습니다. (캐싱 할 이미지가 많을 경우엔 더더욱 좋다고 판단했습니다.)
    - 야곰 아카데미에는 `CoreData` 사용하는 것에 대해서도 제시가 되어있는데 `CoreData`를 사용해서 구현할 경우 `CoreData`에 대한 모듈 자체는 구현 할 것이 그리 많지는 않겠으나 `DetailMovieInfoViewController`의 내부 로직을 변경해야 할 부분이 많아지겠다고 판단하여 부적합한 부분이 있다고 판단했습니다.
- 최대한 기존의 `DetailMovieInfoViewController`의 내부 코드를 수정 하지 않고 Cache를 구현할수 있을지

## 궁금한 점
- 없습니다.